### PR TITLE
subject-chart.html 색상 더 추가

### DIFF
--- a/subject-chart.html
+++ b/subject-chart.html
@@ -182,6 +182,53 @@
         style F2 fill:#FFD072, stroke:#b28704
         style F4 fill:#FFD072, stroke:#b28704
         style F5 fill:#FFD072, stroke:#b28704
+
+        
+        linkStyle 0 stroke:red;
+        linkStyle 1 stroke:blue;
+        linkStyle 2 stroke:green;
+        linkStyle 3 stroke:green;
+        linkStyle 4 stroke:purple;
+        linkStyle 5 stroke:purple;
+        linkStyle 6 stroke:cyan;
+        linkStyle 7 stroke:cyan;
+        linkStyle 8 stroke:lime;
+        linkStyle 9 stroke:lime;
+        linkStyle 10 stroke:lime;
+        linkStyle 11 stroke:magenta;
+        linkStyle 12 stroke:magenta;
+        linkStyle 13 stroke:magenta;
+        linkStyle 14 stroke:gold;
+        linkStyle 15 stroke:green;
+
+        linkStyle 16 stroke:lime;
+        linkStyle 17 stroke:magenta;
+        linkStyle 18 stroke:magenta;
+        linkStyle 19 stroke:green;
+
+        linkStyle 20 stroke:cyan;
+        linkStyle 21 stroke:darkcyan;
+        linkStyle 22 stroke:blue;
+        linkStyle 23 stroke:cyan;
+        linkStyle 24 stroke:cyan;
+
+        linkStyle 25 stroke:magenta;
+        linkStyle 26 stroke:brown;
+        linkStyle 27 stroke:magenta;
+        linkStyle 28 stroke:blue;
+        linkStyle 29 stroke:red;
+        linkStyle 30 stroke:lime;
+        linkStyle 31 stroke:blue;
+        linkStyle 32 stroke:cyan;
+        linkStyle 33 stroke:red;
+        linkStyle 34 stroke:lightcoral;
+        linkStyle 35 stroke:lightsalmon;
+        linkStyle 36 stroke:orange;
+        linkStyle 37 stroke:magenta;
+        linkStyle 38 stroke:cyan;
+        linkStyle 39 stroke:darkpurple;
+        linkStyle 40 stroke:lightgray;
+        
     
     </pre>
 


### PR DESCRIPTION
#102 에서는 몇개만 추가했길래 그래프를 봤을 때 구별이 잘 되게 끔 색상 설정을 전부 했습니다
![image](https://github.com/RakeshC7/HTML5-Boilerplate/assets/127175733/6d0fcaa9-aac5-45d6-b773-e8f07c52ac22)
최대한 겹치는 선들은 구별이 잘 되는 색상들로 지정해 놨습니다

Mermaid 차트에서 각 연결 선의 색상을 다르게 지정하기위해 style 지시어인 linkStyle 명령을 사용하여 각 선들의 색상을 변경하였습니다.
linkStyle 명령어는 연결선의 인덱스(0부터 시작)를 기반으로 적용됩니다.
linkStyle 0 stroke:red;   % A1 --> G1 선
linkStyle 1 stroke:blue;  % A2 --> B1 선
위의 예시에서는 A1에서 G1으로 가는 선이 첫 번째 선이므로 linkStyle 0이 사용되었고, A2에서 B1으로 가는 선은 두 번째 선이므로 linkStyle 1이 사용되었습니다.