### PR TITLE
Dummynode사용으로 그래프 위치 재배치

### DIFF
--- a/subject-chart.html
+++ b/subject-chart.html
@@ -32,29 +32,30 @@
                 B2["정보보호개론"]
                 B3["이산구조"]
                 B4["파이썬프로그래밍"]
-            end
+                end
             end
         
             subgraph "2학년"
             %% 2학년 1학기
-            subgraph "2학년 1학기"
+                subgraph "2학년 1학기"
                 C1["시스템프로그래밍"]
                 C2["시스템보안"]
                 C3["자료구조"]
                 C4["오픈소스sw개발"]
                 C5["컴퓨터네트워크"]
-            end
+                end
             %% 2학년 2학기
-            subgraph "2학년 2학기"
+                subgraph "2학년 2학기"
                 D1["알고리즘"]
                 D2["계산이론"]
                 D3["객체지향프로그래밍"]
                 D4["컴퓨터구조"]
                 D5["임베디드시스템 및 실습"]
                 D6["양자컴퓨팅개론"]
+                end
             end
-            end
-        
+            
+            
             subgraph "3학년"
                 %% 3학년 1학기
                 subgraph "3학년 1학기"
@@ -81,7 +82,7 @@
                 G2["가상증강현실"]
                 G3["게임서버프로그래밍"]
                 G4["데이터베이스프로그래밍"]
-            end
+                end
             %% 4학년 2학기
                 subgraph "4학년 2학기"
                 H1["역공학"]
@@ -89,8 +90,8 @@
                 H3["빅데이터"]
                 H4["클라우드컴퓨팅"]
                 H5["블록체인"]
+                end
             end
-        end
 
         subgraph "캡스톤"
             I1["캡스턴디자인"]
@@ -147,7 +148,19 @@
     
         G4 --> H3
 
+        %% 간격 조정을 위한 더미 노드 추가
         
+        F5 ~~~ ..
+        .. ~~~ G1
+        
+        D6 ~~~ .
+        . ~~~ E1
+        
+    
+        style . fill:none,stroke:none,color:#fff;
+        style .. fill:none,stroke:none,color:#fff;
+
+
         style A1 fill:#fff, stroke:#999999
         style C1 fill:#fff, stroke:#999999
         style C4 fill:#fff, stroke:#999999
@@ -190,18 +203,18 @@
         linkStyle 3 stroke:green;
         linkStyle 4 stroke:purple;
         linkStyle 5 stroke:purple;
-        linkStyle 6 stroke:cyan;
+        linkStyle 6 stroke:red;
         linkStyle 7 stroke:cyan;
         linkStyle 8 stroke:lime;
         linkStyle 9 stroke:lime;
-        linkStyle 10 stroke:lime;
+        linkStyle 10 stroke:olive;
         linkStyle 11 stroke:magenta;
         linkStyle 12 stroke:magenta;
         linkStyle 13 stroke:magenta;
         linkStyle 14 stroke:gold;
         linkStyle 15 stroke:green;
 
-        linkStyle 16 stroke:lime;
+        linkStyle 16 stroke:green;
         linkStyle 17 stroke:magenta;
         linkStyle 18 stroke:magenta;
         linkStyle 19 stroke:green;
@@ -209,8 +222,8 @@
         linkStyle 20 stroke:cyan;
         linkStyle 21 stroke:darkcyan;
         linkStyle 22 stroke:blue;
-        linkStyle 23 stroke:cyan;
-        linkStyle 24 stroke:cyan;
+        linkStyle 23 stroke:red;
+        linkStyle 24 stroke:magenta;
 
         linkStyle 25 stroke:magenta;
         linkStyle 26 stroke:brown;
@@ -229,7 +242,6 @@
         linkStyle 39 stroke:darkpurple;
         linkStyle 40 stroke:lightgray;
         
-    
     </pre>
 
     <script type="module">


### PR DESCRIPTION
![image](https://github.com/oss2024hnu/coursegraph-js/assets/127175733/1a129bcb-97f1-4a61-811b-969e64453f30)
안 보이는 더미 노들를 사용하여 그래프들의 위치를 조정하였습니다. 또, 재배치로 인해 잘 안보이는 선들의 색상도 변경하였습니다.
```javascript
F5 ~~~ ..
.. ~~~ G1
        
D6 ~~~ .
. ~~~ E1
      
style . fill:none,stroke:none,color:#fff;
style .. fill:none,stroke:none,color:#fff;
```
F5 에서 G1 중간에 하나, D6과 E1 사이에 하나 총 두개의 더미 노드를 사용하였습니다
다른 노드들과 더미노드( . 과 .. ) 의 연결선을 안 보이게 하기 위해 "~~~"로 설정하였고, 더미 노드의 텍스트는 안 보이게 하기 위해 style에 color 속성을 사용하여 텍스트의 색상을 배경색과 동일한 하얀색으로 변경하였습니다.

학년별로 구분할 수 있게 배경 색상을 변경하기 전에 수정한 코드라
배경 색상이 사라지지 않게 머지해야할 것 같습니다