### PR TITLE
dummyNode를 사용한 그래프 위치 재배치

### DIFF
--- a/subject-chart.html
+++ b/subject-chart.html
@@ -147,6 +147,14 @@
     
         G4 --> H3
 
+        F5 ~~~ dummyNode1
+        dummyNode1 ~~~ G1
+                
+        D6 ~~~ dummyNode2
+        dummyNode2 ~~~ E1
+            
+        style dummyNode1 fill:none,stroke:none,color:#fff;
+        style dummyNode2 fill:none,stroke:none,color:#fff;
         
         style A1 fill:#fff, stroke:#999999
         style C1 fill:#fff, stroke:#999999
@@ -189,11 +197,11 @@
         linkStyle 2 stroke:green;
         linkStyle 3 stroke:green;
         linkStyle 4 stroke:purple;
-        linkStyle 5 stroke:purple;
+        linkStyle 5 stroke:lime;
         linkStyle 6 stroke:cyan;
         linkStyle 7 stroke:cyan;
         linkStyle 8 stroke:lime;
-        linkStyle 9 stroke:lime;
+        linkStyle 9 stroke:olive;
         linkStyle 10 stroke:lime;
         linkStyle 11 stroke:magenta;
         linkStyle 12 stroke:magenta;
@@ -201,7 +209,7 @@
         linkStyle 14 stroke:gold;
         linkStyle 15 stroke:green;
 
-        linkStyle 16 stroke:lime;
+        linkStyle 16 stroke:darkbrown;
         linkStyle 17 stroke:magenta;
         linkStyle 18 stroke:magenta;
         linkStyle 19 stroke:green;
@@ -209,8 +217,8 @@
         linkStyle 20 stroke:cyan;
         linkStyle 21 stroke:darkcyan;
         linkStyle 22 stroke:blue;
-        linkStyle 23 stroke:cyan;
-        linkStyle 24 stroke:cyan;
+        linkStyle 23 stroke:orange;
+        linkStyle 24 stroke:red;
 
         linkStyle 25 stroke:magenta;
         linkStyle 26 stroke:brown;


### PR DESCRIPTION

![image](https://github.com/oss2024hnu/coursegraph-js/assets/127175733/4ececb62-d65a-4c1b-b5d2-2018a72c4195)

안 보이는 더미 노들를 사용하여 그래프들의 위치를 조정하였습니다. 또, 재배치로 인해 잘 안보이는 선들의 색상도 변경하였습니다.

```javascript
F5 ~~~ dummyNode1
dummyNode1 ~~~ G1
        
D6 ~~~ dummyNode2
dummyNode2 ~~~ E1
```
style dummyNode1 fill:none,stroke:none,color:#fff;
style dummyNode2 fill:none,stroke:none,color:#fff;
F5 에서 G1 중간에 하나, D6과 E1 사이에 하나 총 두개의 더미 노드를 사용하였습니다
다른 노드들과 더미노드( . 과 .. ) 의 연결선을 안 보이게 하기 위해 "~~~"로 설정하였고, 더미 노드의 텍스트는 안 보이게 하기 위해 style에 color 속성을 사용하여 텍스트의 색상을 배경색과 동일한 하얀색으로 변경하였습니다.