### PR TITLE
노드가 선 위로 오도록 만들었습니다.

### DIFF
--- a/css/show.css
+++ b/css/show.css
@@ -14,5 +14,5 @@
 }
 rect {
     stroke: #000;
-    fill: none;
+    fill: white;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -104,8 +104,7 @@ function drawSVGGraph(courses) {
     .attr('height', 40)
     .attr('rx', 5)
     .attr('ry', 5)
-    .attr('stroke', '#000')
-    .attr('fill', 'none');
+    .attr('stroke', '#000');
 
   node
     .append('text')


### PR DESCRIPTION
show.html에서 
이전에는 화살표 선이 위로 올라와서 지저분해보이는 문제가 있었는데
노드의 배경색을 하얀색으로 채움으로써 화살표의 선이 아래로 오도록 만들어 깔끔해보이도록 만들었습니다.