### PR TITLE
검색 기능을 이용할 때 공백이 아닌 다른 문자가 들어가면 '일치하는 과목을 찾을 수 없습니다.'가 뜨지 않는 문제

### DIFF
--- a/js/subject-chart-module.js
+++ b/js/subject-chart-module.js
@@ -9,6 +9,8 @@
                 if (isFirstSearch || searchText !== text) {
                     isFirstSearch = false;
                     searchText = text;
+                    let input = document.getElementById("SearchTxt");
+                    input.value = "";
                     if (!window.find(text, false, false, true, false, false, false)) {
                         alert('일치하는 과목을 찾을 수 없습니다.');
                         isFirstSearch = true;


### PR DESCRIPTION
검색 기능을 이용할 때 공백이 아닌 다른 문자가 들어가면 '일치하는 과목을 찾을 수 없습니다.'가 뜨지 않는 문제를 해결했습니다.