### PR TITLE
다크모드로 png를 저장할때 다크모드 상태로 저장이 되도록 변경

### DIFF
--- a/subject-chart.html
+++ b/subject-chart.html
@@ -278,11 +278,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script>
         document.getElementById('saveAsPngBtn').addEventListener('click', function () {
-            html2canvas(document.querySelector("#subjectChart")).then(canvas => {
-                const link = document.createElement('a');
-                link.download = 'subject-chart.png';
-                link.href = canvas.toDataURL("image/png");
-                link.click();
+            const isDarkMode = document.body.classList.contains('dark-mode');
+            html2canvas(document.querySelector("#subjectChart"), {
+                backgroundColor: isDarkMode ? '#121212' : '#ffffff'
+            }).then(canvas => {
+              const link = document.createElement('a');
+              link.download = 'subject-chart.png';
+              link.href = canvas.toDataURL("image/png");
+              link.click();
             });
         });
 


### PR DESCRIPTION
![subject-chart (15)](https://github.com/oss2024hnu/coursegraph-js/assets/146164867/f19e6fa6-42a6-46e1-b361-b2ec1cd0f6f9)

이러한 형태로 다크모드 활성화 후 png 저장을 하였을때 다크모드 상태로 저장이 되도록 변경하였습니다.